### PR TITLE
Added pagination logic to getting all users

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,5 +1,5 @@
-const User = require("./../models/userModel");
-const catchAsync = require("./../utils/catchAsync");
+const User = require('./../models/userModel');
+const catchAsync = require('./../utils/catchAsync');
 
 //Added pagination logic to the getAllUsers controller
 exports.getAllUsers = catchAsync(async (req, res, next) => {
@@ -19,7 +19,7 @@ exports.getAllUsers = catchAsync(async (req, res, next) => {
 
     // Send response with pagination information
     res.status(200).json({
-      status: "Success",
+      status: 'Success',
       data: {
         results: users.length,
         users,
@@ -30,7 +30,7 @@ exports.getAllUsers = catchAsync(async (req, res, next) => {
     });
   } catch (err) {
     res.status(404).json({
-      status: "fail",
+      status: 'fail',
       message: err.message,
     });
   }
@@ -38,25 +38,25 @@ exports.getAllUsers = catchAsync(async (req, res, next) => {
 
 exports.createUser = (req, res) => {
   res.status(500).json({
-    status: "error",
-    message: "this route is not defined yet",
+    status: 'error',
+    message: 'this route is not defined yet',
   });
 };
 exports.getUser = (req, res) => {
   res.status(500).json({
-    status: "error",
-    message: "this route is not defined yet",
+    status: 'error',
+    message: 'this route is not defined yet',
   });
 };
 exports.updateUser = (req, res) => {
   res.status(500).json({
-    status: "error",
-    message: "this route is not defined yet",
+    status: 'error',
+    message: 'this route is not defined yet',
   });
 };
 exports.deleteUser = (req, res) => {
   res.status(500).json({
-    status: "error",
-    message: "this route is not defined yet",
+    status: 'error',
+    message: 'this route is not defined yet',
   });
 };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,19 +1,36 @@
-const User = require('./../models/userModel');
-const catchAsync = require('./../utils/catchAsync');
+const User = require("./../models/userModel");
+const catchAsync = require("./../utils/catchAsync");
 
+//Added pagination logic to the getAllUsers controller
 exports.getAllUsers = catchAsync(async (req, res, next) => {
+  // Set default values for page and limit
+  const page = parseInt(req.query.page, 10) || 1;
+  const pageSize = parseInt(req.query.pageSize, 10) || 10;
+
+  // Calculate the skip based on the page and pageSize
+  const skip = (page - 1) * pageSize;
+
   try {
-    const users = await User.find();
+    // Find all users with pagination
+    const users = await User.find().skip(skip).limit(pageSize);
+
+    // Calculate the total number of users
+    const totalUsers = await User.countDocuments();
+
+    // Send response with pagination information
     res.status(200).json({
-      status: 'Success',
+      status: "Success",
       data: {
         results: users.length,
         users,
+        page,
+        pageSize,
+        totalUsers,
       },
     });
   } catch (err) {
     res.status(404).json({
-      status: 'fail',
+      status: "fail",
       message: err.message,
     });
   }
@@ -21,25 +38,25 @@ exports.getAllUsers = catchAsync(async (req, res, next) => {
 
 exports.createUser = (req, res) => {
   res.status(500).json({
-    status: 'error',
-    message: 'this route is not defined yet',
+    status: "error",
+    message: "this route is not defined yet",
   });
 };
 exports.getUser = (req, res) => {
   res.status(500).json({
-    status: 'error',
-    message: 'this route is not defined yet',
+    status: "error",
+    message: "this route is not defined yet",
   });
 };
 exports.updateUser = (req, res) => {
   res.status(500).json({
-    status: 'error',
-    message: 'this route is not defined yet',
+    status: "error",
+    message: "this route is not defined yet",
   });
 };
 exports.deleteUser = (req, res) => {
   res.status(500).json({
-    status: 'error',
-    message: 'this route is not defined yet',
+    status: "error",
+    message: "this route is not defined yet",
   });
 };


### PR DESCRIPTION
This PR adds pagination functionality to the getAllUsers controller to limit the number of users returned per page and provide pagination information in the response. It calculates the skip value based on the page and pageSize query parameters, queries the database using skip and limit, and includes pagination metadata such as the current page, page size, and total number of users in the response.